### PR TITLE
Resolve ExportFeed issue

### DIFF
--- a/App Resources/NHMD/ExportFeed.xml
+++ b/App Resources/NHMD/ExportFeed.xml
@@ -17,11 +17,11 @@
       <title>NHMD Danekræ Fossil Trove Collection</title>
       <id>d9c16c4c-7102-4783-9225-4eb0ab079eb2</id>
     </item>
-    <item collectionId="4" userId="64" notifyUserId="64" definition="DwCA VP" metadata="DwCA VP.eml" days="1" filename="DwCA-VP.zip" publish="true">
+    <item collectionId="4" userId="64" notifyUserId="64" definition="DwCA-VP" metadata="DwCA-VP.eml" days="1" filename="DwCA-VP.zip" publish="true">
       <title>NHMD Vertebrate Paleontology Collection</title>
       <id>4159fce0-b720-425d-8020-7c76d1636490</id>
     </item>
-    <item collectionId="491522" userId="64" notifyUserId="64" definition="DwCA MM" metadata="DwCA MM.eml" days="1" filename="DwCA-MM.zip" publish="true">
+    <item collectionId="491522" userId="64" notifyUserId="64" definition="DwCA-MM" metadata="DwCA-MM.eml" days="1" filename="DwCA-MM.zip" publish="true">
       <title>NHMD Mammalogy Collection</title>
       <id>c37f3fc6-919b-4e82-aa9f-fc815512422e</id>
     </item>
@@ -29,7 +29,7 @@
       <title>NHMD Invertebrate Zoology Collection</title>
       <id>83e2601a-a820-11eb-bcbc-0242ac130002</id>
     </item>
-    <item collectionId="458754" userId="64" notifyUserId="64" definition="DwCA AV" metadata="DwCA AV.eml" days="1" filename="DwCA-AV.zip" publish="true">
+    <item collectionId="458754" userId="64" notifyUserId="64" definition="DwCA-AV" metadata="DwCA-AV.eml" days="1" filename="DwCA-AV.zip" publish="true">
       <title>NHMD Ornithology Collection</title>
       <id>fc69d180-c4f9-11eb-8529-0242ac130003</id>
     </item>
@@ -41,7 +41,7 @@
       <title>NHMD Entomology Collection</title>
       <id>40d23ef2-c4f5-11eb-8529-0242ac130003</id>
     </item>
-    <item collectionId="557056" userId="64" notifyUserId="64" definition="DwCA QZ" metadata="DwCA-QZ.eml" days="1" filename="DwCA-QZ.zip" publish="true">
+    <item collectionId="557056" userId="64" notifyUserId="64" definition="DwCA-QZ" metadata="DwCA-QZ.eml" days="1" filename="DwCA-QZ.zip" publish="true">
       <title>NHMD Quaternary Zoology</title>
       <id>d5aab4ae-2a87-4ba9-8ffb-b504f7a44611</id>
     </item>


### PR DESCRIPTION
There was an issue preventing a successful RSS feed update due to the `ExportFeed` app resource being defined incorrectly as the referenced app resources did not exist in the database.

This issue was masked initially by the manual export being run in the wrong collection (leading to https://github.com/specify/specify7/issues/2920).


It appears all exports now run correctly with this change applied:

<img width="1136" alt="image" src="https://github.com/user-attachments/assets/237060b1-8f1b-41f0-9ab4-48e1fb4d4e55">

<img width="1136" alt="image" src="https://github.com/user-attachments/assets/c539cd90-2a91-4a4e-802c-dd34e685883b">


Let me know if you have any trouble after making this change!